### PR TITLE
fix(icon): update HttpClient provider guidance

### DIFF
--- a/projects/ng-aquila/src/icon/icon.md
+++ b/projects/ng-aquila/src/icon/icon.md
@@ -210,7 +210,7 @@ For the components to use your desired icons for the essential icons list you ca
 
 ### Register icons service
 
-Custom icons can be registered via the `NxIconRegistry` injectable service. With the `NxIconRegistry` you can associate icon names with SVG, URL and HTML strings and define a CSS font class. When you are registering an icon by URL please make sure to import the `HttpClientModule` from `@angular/common/http`.
+Custom icons can be registered via the `NxIconRegistry` injectable service. With the `NxIconRegistry` you can associate icon names with SVG, URL and HTML strings and define a CSS font class. When you are registering an icon by URL, add `provideHttpClient()` from `@angular/common/http` to your application's providers.
 
 💡 When registering multiple font sets,
 you can use `font` attribute to specify font set (`<nx-icon font="FONT_SET_NAME" name="ICON_NAME">`)

--- a/projects/ng-aquila/src/icon/icons.ts
+++ b/projects/ng-aquila/src/icon/icons.ts
@@ -79,7 +79,7 @@ export class NxSvgIconFromUrl extends NxSvgIcon {
     if (!_httpClient) {
       throw Error(
         'Could not find HttpClient provider for using a SVG url in the nx-icon registry. ' +
-          'Please include the HttpClientModule from @angular/common/http in your app imports.',
+          'Please add provideHttpClient() from @angular/common/http to your app providers.',
       );
     }
     this._httpClient = _httpClient;

--- a/projects/ng-aquila/src/icon/icons.ts
+++ b/projects/ng-aquila/src/icon/icons.ts
@@ -78,8 +78,8 @@ export class NxSvgIconFromUrl extends NxSvgIcon {
     }
     if (!_httpClient) {
       throw Error(
-        'Could not find HttpClient provider for using a SVG url in the nx-icon registry. ' +
-          'Please add provideHttpClient() from @angular/common/http to your app providers.',
+        'Could not find an HttpClient provider for loading an SVG URL with NxIconRegistry. ' +
+          "Please add provideHttpClient() from @angular/common/http to your application's providers.",
       );
     }
     this._httpClient = _httpClient;


### PR DESCRIPTION
### Requirements

Please read the contribution guidelines :notebook_with_decorative_cover: beforehand and if in doubt reach out to us :pray:

#### Definition of Done

**Mandatory for all PRs**

- [x] All unit and build tests are green 🚦
- [ ] Reviewed and approved by maintainer :+1:

**Applicable to some PRs**

- [ ] W3C AA accessibility fulfilled
- [x] Documentation and examples are updated
- [ ] Tested on all supported browsers (see `Getting Started`)
- [ ] Unit tests with good coverage (e.g., >80%)
- [x] No unintended visual changes. If needed, run the visual regression testing (see `README.md`)

Accessibility and supported-browser testing are not applicable because this only updates setup guidance and an error message. No unit test was added because asserting exact error wording would be brittle.

### Description of the Change

Replace deprecated `HttpClientModule` guidance for URL-based icons with Angular's provider-based `provideHttpClient()` API in:

- the icon documentation
- the missing-`HttpClient` runtime error

### Why should this be in the library?

Angular deprecates `HttpClientModule`, but the icon documentation currently instructs consumers to import it. This change keeps the documentation and runtime guidance aligned with Angular's current API.

Closes #76.
