### PR TITLE
feat(styles): expose Sass breakpoint utilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,5 +48,8 @@ jobs:
       - name: Build ng-aquila
         run: npm run build:lib
 
+      - name: Test styles package
+        run: npm run test:styles-package
+
       - name: Build documentation
         run: npm run build:docs -- --progress=false

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test:docs-ui": "ng test ngx-docs-ui",
     "test:docs-ui:coverage": "ng test ngx-docs-ui --watch=false --code-coverage",
     "test:schematics": "npm run build:package && jasmine --config=projects/ng-aquila/src/schematics/test/jasmine.json",
+    "test:styles-package": "node ./scripts/test-styles-package.mjs",
     "browserslist": "browserslist --coverage && browserslist",
     "browserslist:update": "browserslist --update-db",
     "library:generate:docs": "npm run cli -- generate projects/ng-aquila",

--- a/projects/ng-aquila/src/sass-utilities/sass-utilities.md
+++ b/projects/ng-aquila/src/sass-utilities/sass-utilities.md
@@ -1,0 +1,127 @@
+---
+title: Sass utilities
+category: general
+b2c: true
+expert: true
+stable: done
+noApi: true
+a1Light: true
+---
+
+The library ships a small set of Sass helpers so you can align your own styles with the same
+breakpoints the components use. They are available as a `@use` entry point, no `@import` needed:
+
+```scss
+@use '@allianz/ng-aquila/styles/utils' as aquila;
+
+.my-card {
+  padding: 16px;
+
+  @include aquila.media-breakpoint-up(medium) {
+    padding: 24px;
+  }
+}
+```
+
+### Media queries
+
+Each mixin takes a breakpoint name and wraps its content in the matching media query.
+`media-breakpoint-between` takes a lower and an upper breakpoint.
+
+| Mixin | Description |
+| --- | --- |
+| `media-breakpoint-up($name)` | Applies from the given breakpoint upwards. No query is emitted for the smallest breakpoint. |
+| `media-breakpoint-down($name)` | Applies from the given breakpoint downwards. No query is emitted for the largest breakpoint. |
+| `media-breakpoint-between($lower, $upper)` | Applies between the two given breakpoints. |
+| `media-breakpoint-only($name)` | Applies only within the given breakpoint. |
+
+```scss
+@use '@allianz/ng-aquila/styles/utils' as aquila;
+
+.my-teaser {
+  @include aquila.media-breakpoint-only(medium) {
+    display: none;
+  }
+}
+```
+
+### Container queries
+
+The same breakpoints are available as container queries, for components that should respond to
+their container instead of the viewport. Remember to set `container-type` on the containing element.
+
+| Mixin | Description |
+| --- | --- |
+| `container-breakpoint-up($name)` | Applies from the given breakpoint upwards. |
+| `container-breakpoint-down($name)` | Applies from the given breakpoint downwards. |
+
+```scss
+@use '@allianz/ng-aquila/styles/utils' as aquila;
+
+.my-panel {
+  container-type: inline-size;
+}
+
+.my-panel__content {
+  @include aquila.container-breakpoint-up(large) {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+}
+```
+
+### Breakpoint values
+
+`$grid-breakpoints` holds the breakpoint names and their minimum widths.
+
+| Name | Min width |
+| --- | --- |
+| `xsmall` | 0 |
+| `small` | 320px |
+| `medium` | 704px |
+| `large` | 992px |
+| `xlarge` | 1280px |
+| `2xlarge` | 1472px |
+| `3xlarge` | 1760px |
+
+The main entry point also exposes `$grid-breakpoints-short` (the same map keyed `xs` … `3xl`),
+`$grid-columns` and `$grid-gutter-widths`.
+
+The directly importable `@allianz/ng-aquila/styles/utils/grid` module additionally exposes the
+individual `$grid-gutter-width-large`, `$grid-gutter-width-base` and
+`$grid-gutter-width-mobile` values.
+
+Every mixin and function accepts an optional `$breakpoints` argument, so you can pass your own map
+instead of the library defaults:
+
+```scss
+@use '@allianz/ng-aquila/styles/utils' as aquila;
+
+$my-breakpoints: (
+  small: 0,
+  large: 900px,
+);
+
+.my-component {
+  @include aquila.media-breakpoint-up(large, $my-breakpoints) {
+    display: flex;
+  }
+}
+```
+
+### Functions
+
+| Function | Description |
+| --- | --- |
+| `breakpoint-min($name)` | Minimum width of a breakpoint, or `null` for the smallest one. |
+| `breakpoint-max($name)` | Maximum width of a breakpoint, or `null` for the largest one. |
+| `breakpoint-next($name)` | Name of the next larger breakpoint, or `null`. |
+| `breakpoint-infix($name)` | `""` for the smallest breakpoint, otherwise `"-#{$name}"`. Useful for generating responsive class names. |
+
+### Supported scope
+
+The Sass modules shipped under `styles/utils` and their members are supported. Other files from the
+library's internal `shared-styles` source folder are not public API.
+
+Theming has its own supported entry point at `styles/theming`, described in
+[Theming](./documentation/theming/overview).

--- a/projects/ng-aquila/src/sass-utilities/sass-utilities.md
+++ b/projects/ng-aquila/src/sass-utilities/sass-utilities.md
@@ -84,6 +84,9 @@ their container instead of the viewport. Remember to set `container-type` on the
 | `2xlarge` | 1472px |
 | `3xlarge` | 1760px |
 
+Breakpoint keys beginning with a digit, such as `2xlarge`, `3xlarge`, `2xl` and `3xl`, are Sass
+numbers with custom units. Use them unquoted when calling helpers or accessing the maps.
+
 The main entry point also exposes `$grid-breakpoints-short` (the same map keyed `xs` … `3xl`),
 `$grid-columns` and `$grid-gutter-widths`.
 

--- a/projects/ng-aquila/src/shared-styles/breakpoint.scss
+++ b/projects/ng-aquila/src/shared-styles/breakpoint.scss
@@ -1,93 +1,16 @@
-@use 'sass:list';
-@use 'sass:map';
-@use './grid' as *;
-
-// Breakpoint viewport sizes and media queries.
-
-@function breakpoint-next(
-  $name,
-  $breakpoints: $grid-breakpoints,
-  $breakpoint-names: map.keys($breakpoints)
-) {
-  $n: list.index($breakpoint-names, $name);
-  @return if($n < list.length($breakpoint-names), list.nth($breakpoint-names, $n + 1), null);
-}
-
-// Minimum breakpoint width. Null for the smallest (first) breakpoint.
+// Internal compatibility wrapper.
 //
-//    >> breakpoint-min(sm, (xs: 0, sm: 376px, md: 768px))
-//    376px
-@function breakpoint-min($name, $breakpoints: $grid-breakpoints) {
-  $min: map.get($breakpoints, $name);
-  @return if($min != 0, $min, null);
-}
-
-// Maximum breakpoint width. Null for the largest (last) breakpoint.
-// The maximum value is calculated as the minimum of the next one less 0.1.
+// The supported breakpoint and container query helpers live in `./breakpoints`, which is shipped as
+// `@allianz/ng-aquila/styles/utils/breakpoints`. Only the legacy members below stay internal - they
+// are not part of the published package and are scheduled for removal.
 //
-//    767px
-@function breakpoint-max($name, $breakpoints: $grid-breakpoints) {
-  $next: breakpoint-next($name, $breakpoints);
-  @return if($next, breakpoint-min($next, $breakpoints) - 1px, null);
-}
+// `@forward` re-exports `./breakpoints` to everything that uses this file (mainly `./index`), while
+// `@use` additionally brings those members into this file's own scope, which the legacy mixins below
+// need.
+@forward './breakpoints';
+@use './breakpoints' as *;
 
-// Returns a blank string if smallest breakpoint, otherwise returns the name with a dash infront.
-// Useful for making responsive utilities.
-//
-//    >> breakpoint-infix(xs, (xs: 0, sm: 376px, md: 768px))
-//    ""  (Returns a blank string)
-//    >> breakpoint-infix(sm, (xs: 0, sm: 376px, md: 768px))
-//    "-sm"
-@function breakpoint-infix($name, $breakpoints: $grid-breakpoints) {
-  @return if(breakpoint-min($name, $breakpoints) == null, '', '-#{$name}');
-}
-
-// Media of at least the minimum breakpoint width. No query for the smallest breakpoint.
-// Makes the @content apply to the given breakpoint and wider.
-@mixin media-breakpoint-up($name, $breakpoints: $grid-breakpoints) {
-  $min: breakpoint-min($name, $breakpoints);
-  @if $min {
-    @media (min-width: $min) {
-      @content;
-    }
-  } @else {
-    @content;
-  }
-}
-
-// Media of at most the maximum breakpoint width. No query for the largest breakpoint.
-// Makes the @content apply to the given breakpoint and narrower.
-@mixin media-breakpoint-down($name, $breakpoints: $grid-breakpoints) {
-  $max: breakpoint-max($name, $breakpoints);
-  @if $max {
-    @media (max-width: $max) {
-      @content;
-    }
-  } @else {
-    @content;
-  }
-}
-
-// Media that spans multiple breakpoint widths.
-// Makes the @content apply between the min and max breakpoints
-@mixin media-breakpoint-between($lower, $upper, $breakpoints: $grid-breakpoints) {
-  @include media-breakpoint-up($lower, $breakpoints) {
-    @include media-breakpoint-down($upper, $breakpoints) {
-      @content;
-    }
-  }
-}
-
-// Media between the breakpoint's minimum and maximum widths.
-// No minimum for the smallest breakpoint, and no maximum for the largest one.
-// Makes the @content apply only to the given breakpoint, not viewports any wider or narrower.
-@mixin media-breakpoint-only($name, $breakpoints: $grid-breakpoints) {
-  @include media-breakpoint-between($name, $name, $breakpoints) {
-    @content;
-  }
-}
-
-// TODO This is for backwards compaitibility, Remove respond-to calls with corresponding media-breakpoint-up.
+// TODO: This is for backwards compatibility. Replace respond-to calls with media-breakpoint-up.
 $screen-small-1: 685px;
 
 @mixin respond-to($size) {
@@ -127,31 +50,5 @@ $screen-small-1: 685px;
     @include media-breakpoint-up(large) {
       @content;
     }
-  }
-}
-
-// Media of at most the maximum breakpoint width. No query for the largest breakpoint.
-// Makes the @content apply to the given breakpoint and narrower.
-@mixin container-breakpoint-down($name, $breakpoints: $grid-breakpoints) {
-  $max: breakpoint-max($name, $breakpoints);
-  @if $max {
-    @container (max-width: #{$max}) {
-      @content;
-    }
-  } @else {
-    @content;
-  }
-}
-
-// Media of at least the minimum breakpoint width. No query for the smallest breakpoint.
-// Makes the @content apply to the given breakpoint and wider.
-@mixin container-breakpoint-up($name, $breakpoints: $grid-breakpoints) {
-  $min: breakpoint-min($name, $breakpoints);
-  @if $min {
-    @container (min-width: #{$min} ) {
-      @content;
-    }
-  } @else {
-    @content;
   }
 }

--- a/projects/ng-aquila/src/shared-styles/breakpoints.scss
+++ b/projects/ng-aquila/src/shared-styles/breakpoints.scss
@@ -15,7 +15,10 @@
   $breakpoint-names: map.keys($breakpoints)
 ) {
   $n: list.index($breakpoint-names, $name);
-  @return if($n < list.length($breakpoint-names), list.nth($breakpoint-names, $n + 1), null);
+  @if $n == null or $n >= list.length($breakpoint-names) {
+    @return null;
+  }
+  @return list.nth($breakpoint-names, $n + 1);
 }
 
 // Minimum breakpoint width. Null for the smallest (first) breakpoint.

--- a/projects/ng-aquila/src/shared-styles/breakpoints.scss
+++ b/projects/ng-aquila/src/shared-styles/breakpoints.scss
@@ -1,0 +1,119 @@
+@use 'sass:list';
+@use 'sass:map';
+@use './grid' as *;
+
+// Public breakpoint and container query helpers.
+//
+// These members are forwarded by the supported `@allianz/ng-aquila/styles/utils` entry point.
+// Legacy helpers that should not be exposed live in the internal `./breakpoint` wrapper instead.
+//
+// All helpers accept a `$breakpoints` map so consumers can pass their own instead of `$grid-breakpoints`.
+
+@function breakpoint-next(
+  $name,
+  $breakpoints: $grid-breakpoints,
+  $breakpoint-names: map.keys($breakpoints)
+) {
+  $n: list.index($breakpoint-names, $name);
+  @return if($n < list.length($breakpoint-names), list.nth($breakpoint-names, $n + 1), null);
+}
+
+// Minimum breakpoint width. Null for the smallest (first) breakpoint.
+//
+//    >> breakpoint-min(sm, (xs: 0, sm: 376px, md: 768px))
+//    376px
+@function breakpoint-min($name, $breakpoints: $grid-breakpoints) {
+  $min: map.get($breakpoints, $name);
+  @return if($min != 0, $min, null);
+}
+
+// Maximum breakpoint width. Null for the largest (last) breakpoint.
+// The maximum value is the next breakpoint's minimum width minus 1px.
+//
+//    767px
+@function breakpoint-max($name, $breakpoints: $grid-breakpoints) {
+  $next: breakpoint-next($name, $breakpoints);
+  @return if($next, breakpoint-min($next, $breakpoints) - 1px, null);
+}
+
+// Returns a blank string for the smallest breakpoint, otherwise the name with a dash in front.
+// Useful for making responsive utilities.
+//
+//    >> breakpoint-infix(xs, (xs: 0, sm: 376px, md: 768px))
+//    ""  (Returns a blank string)
+//    >> breakpoint-infix(sm, (xs: 0, sm: 376px, md: 768px))
+//    "-sm"
+@function breakpoint-infix($name, $breakpoints: $grid-breakpoints) {
+  @return if(breakpoint-min($name, $breakpoints) == null, '', '-#{$name}');
+}
+
+// Media of at least the minimum breakpoint width. No query for the smallest breakpoint.
+// Makes the @content apply to the given breakpoint and wider.
+@mixin media-breakpoint-up($name, $breakpoints: $grid-breakpoints) {
+  $min: breakpoint-min($name, $breakpoints);
+  @if $min {
+    @media (min-width: $min) {
+      @content;
+    }
+  } @else {
+    @content;
+  }
+}
+
+// Media of at most the maximum breakpoint width. No query for the largest breakpoint.
+// Makes the @content apply to the given breakpoint and narrower.
+@mixin media-breakpoint-down($name, $breakpoints: $grid-breakpoints) {
+  $max: breakpoint-max($name, $breakpoints);
+  @if $max {
+    @media (max-width: $max) {
+      @content;
+    }
+  } @else {
+    @content;
+  }
+}
+
+// Media that spans multiple breakpoint widths.
+// Makes the @content apply between the min and max breakpoints.
+@mixin media-breakpoint-between($lower, $upper, $breakpoints: $grid-breakpoints) {
+  @include media-breakpoint-up($lower, $breakpoints) {
+    @include media-breakpoint-down($upper, $breakpoints) {
+      @content;
+    }
+  }
+}
+
+// Media between the breakpoint's minimum and maximum widths.
+// No minimum for the smallest breakpoint, and no maximum for the largest one.
+// Makes the @content apply only to the given breakpoint, not viewports any wider or narrower.
+@mixin media-breakpoint-only($name, $breakpoints: $grid-breakpoints) {
+  @include media-breakpoint-between($name, $name, $breakpoints) {
+    @content;
+  }
+}
+
+// Container of at most the maximum breakpoint width. No query for the largest breakpoint.
+// Makes the @content apply to the given breakpoint and narrower.
+@mixin container-breakpoint-down($name, $breakpoints: $grid-breakpoints) {
+  $max: breakpoint-max($name, $breakpoints);
+  @if $max {
+    @container (max-width: #{$max}) {
+      @content;
+    }
+  } @else {
+    @content;
+  }
+}
+
+// Container of at least the minimum breakpoint width. No query for the smallest breakpoint.
+// Makes the @content apply to the given breakpoint and wider.
+@mixin container-breakpoint-up($name, $breakpoints: $grid-breakpoints) {
+  $min: breakpoint-min($name, $breakpoints);
+  @if $min {
+    @container (min-width: #{$min}) {
+      @content;
+    }
+  } @else {
+    @content;
+  }
+}

--- a/projects/ng-aquila/src/shared-styles/public-utils.scss
+++ b/projects/ng-aquila/src/shared-styles/public-utils.scss
@@ -1,0 +1,12 @@
+// Public entry point for the Sass utilities shipped with the package.
+//
+// Copied to `dist/ng-aquila/styles/utils/_index.scss` by `scripts/build-package.js`, so consumers
+// reach it as:
+//
+//     @use '@allianz/ng-aquila/styles/utils' as aquila;
+//
+// These forwards define the preferred entry point. Files copied alongside it are also reachable by
+// consumers, so the build copies only files whose complete surface is suitable as public API.
+@forward './breakpoints';
+@forward './grid' show $grid-breakpoints, $grid-breakpoints-short, $grid-columns,
+  $grid-gutter-widths;

--- a/scripts/build-package.js
+++ b/scripts/build-package.js
@@ -55,6 +55,34 @@ function globCopy(sourcePath, destinationPath, globPath) {
   });
 }
 
+/**
+ * Sass files required by the public `@allianz/ng-aquila/styles/utils` entry point.
+ *
+ * Sass does not provide a privacy boundary for copied files: consumers can import every file in
+ * this list directly. Keep the list explicit and copy only files whose complete surface is suitable
+ * as supported public API. The forwards in `public-utils.scss` provide the preferred entry point.
+ *
+ * Names are preserved because the copy does not rewrite `@use` specifiers, so any file that another
+ * copied file imports must keep its source name. `public-utils.scss` is the only exception: nothing
+ * imports it, and the rename is what lets `@use '.../styles/utils'` resolve to the directory.
+ */
+const PUBLIC_STYLE_UTILS = [
+  ['public-utils.scss', '_index.scss'],
+  ['breakpoints.scss', 'breakpoints.scss'],
+  ['grid.scss', 'grid.scss'],
+];
+
+function copyPublicStyleUtils() {
+  rimrafSync('dist/ng-aquila/styles/utils');
+
+  PUBLIC_STYLE_UTILS.forEach(([source, destination]) => {
+    fs.copySync(
+      `projects/ng-aquila/src/shared-styles/${source}`,
+      `dist/ng-aquila/styles/utils/${destination}`,
+    );
+  });
+}
+
 function compileSchematics() {
   rimrafSync('./dist/ng-aquila/schematics');
 
@@ -106,7 +134,8 @@ compileSchematics();
 
 console.log('============================');
 console.log('  Copying scss sources');
-fs.copy(`projects/ng-aquila/src/shared-styles/theming`, `dist/ng-aquila/styles`);
+fs.copySync(`projects/ng-aquila/src/shared-styles/theming`, `dist/ng-aquila/styles`);
+copyPublicStyleUtils();
 
 console.log('============================');
 console.log('  Copying other assets');

--- a/scripts/test-styles-package.mjs
+++ b/scripts/test-styles-package.mjs
@@ -15,6 +15,7 @@ import chalk from 'chalk';
 const DIST = 'dist/ng-aquila';
 const UTILS_DIR = `${DIST}/styles/utils`;
 const EXPECTED_FILES = ['_index.scss', 'breakpoints.scss', 'grid.scss'];
+const SASS_CLI = path.resolve('node_modules/sass/sass.js');
 
 const failures = [];
 
@@ -41,8 +42,13 @@ function compileFixture(consumerRoot, source) {
   fs.writeFileSync(entry, source);
   try {
     const css = execFileSync(
-      'npx',
-      ['sass', '--no-source-map', `--load-path=${path.join(consumerRoot, 'node_modules')}`, entry],
+      process.execPath,
+      [
+        SASS_CLI,
+        '--no-source-map',
+        `--load-path=${path.join(consumerRoot, 'node_modules')}`,
+        entry,
+      ],
       { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
     );
     return { css };
@@ -131,6 +137,10 @@ try {
       `@use '@allianz/ng-aquila/styles/utils' as aquila;
 @use '@allianz/ng-aquila/styles/utils/grid' as grid;
 @use 'sass:map';
+
+@if aquila.breakpoint-next(unknown) != null {
+  @error 'Expected an unknown breakpoint to have no successor.';
+}
 
 .a {
   min-width: aquila.breakpoint-min(medium);

--- a/scripts/test-styles-package.mjs
+++ b/scripts/test-styles-package.mjs
@@ -1,0 +1,212 @@
+import { execFileSync } from 'child_process';
+import os from 'os';
+import path from 'path';
+import fs from 'fs-extra';
+import { rimrafSync } from 'rimraf';
+import chalk from 'chalk';
+
+/**
+ * Verifies the public Sass utilities shipped at `@allianz/ng-aquila/styles/utils`.
+ *
+ * Run after `npm run build:lib`. Nothing in this repository compiles the copied scss tree, so a
+ * broken `@use` specifier in `dist` would otherwise only surface in a consumer's build.
+ */
+
+const DIST = 'dist/ng-aquila';
+const UTILS_DIR = `${DIST}/styles/utils`;
+const EXPECTED_FILES = ['_index.scss', 'breakpoints.scss', 'grid.scss'];
+
+const failures = [];
+
+function check(description, fn) {
+  try {
+    fn();
+    console.log(`  ${chalk.green('✓')} ${description}`);
+  } catch (error) {
+    failures.push({ description, error });
+    console.log(`  ${chalk.red('✗')} ${description}`);
+    console.log(`    ${chalk.red(error.message)}`);
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+/** Compiles `source` against the package and returns { css } or { error }. */
+function compileFixture(consumerRoot, source) {
+  const entry = path.join(consumerRoot, 'fixture.scss');
+  fs.writeFileSync(entry, source);
+  try {
+    const css = execFileSync(
+      'npx',
+      ['sass', '--no-source-map', `--load-path=${path.join(consumerRoot, 'node_modules')}`, entry],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    return { css };
+  } catch (error) {
+    return { error: `${error.stderr ?? ''}${error.stdout ?? ''}` };
+  }
+}
+
+console.log('============================');
+console.log('  Testing styles package');
+
+assert(
+  fs.existsSync(UTILS_DIR),
+  `${UTILS_DIR} does not exist - run "npm run build:lib" before this script.`,
+);
+
+// Keep the public surface explicit. A stray addition would silently create another supported
+// deep-import path.
+check(`${UTILS_DIR} contains exactly the expected files`, () => {
+  const actual = fs.readdirSync(UTILS_DIR).sort();
+  assert(
+    JSON.stringify(actual) === JSON.stringify([...EXPECTED_FILES].sort()),
+    `expected [${EXPECTED_FILES.join(', ')}] but found [${actual.join(', ')}]`,
+  );
+});
+
+// The pre-existing theming entry point must keep working.
+check('styles/theming.scss is still packaged', () => {
+  assert(fs.existsSync(`${DIST}/styles/theming.scss`), `${DIST}/styles/theming.scss is missing`);
+});
+
+// Resolve the package the way a consumer does: through node_modules, under its scoped name.
+const consumerRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ng-aquila-styles-'));
+const packageDir = path.join(consumerRoot, 'node_modules', '@allianz', 'ng-aquila');
+
+try {
+  fs.ensureDirSync(path.dirname(packageDir));
+  fs.copySync(DIST, packageDir);
+
+  check('the public entry point compiles and emits the expected queries', () => {
+    const { css, error } = compileFixture(
+      consumerRoot,
+      `@use '@allianz/ng-aquila/styles/utils' as aquila;
+
+.a {
+  @include aquila.media-breakpoint-up(medium) { color: red; }
+}
+.b {
+  @include aquila.media-breakpoint-down(medium) { color: green; }
+}
+.c {
+  @include aquila.container-breakpoint-up(large) { color: blue; }
+}
+.d {
+  @include aquila.media-breakpoint-between(medium, large) { color: purple; }
+}
+.e {
+  @include aquila.media-breakpoint-only(medium) { color: orange; }
+}
+.f {
+  @include aquila.container-breakpoint-down(medium) { color: black; }
+}
+`,
+    );
+    assert(!error, `compilation failed:\n${error}`);
+    assert(css.includes('@media (min-width: 704px)'), `missing min-width query in:\n${css}`);
+    assert(css.includes('@media (max-width: 991px)'), `missing max-width query in:\n${css}`);
+    assert(css.includes('@container (min-width: 992px)'), `missing container query in:\n${css}`);
+    assert(
+      css.includes('@media (min-width: 704px) and (max-width: 1279px)'),
+      `missing between query in:\n${css}`,
+    );
+    assert(
+      css.includes('@media (min-width: 704px) and (max-width: 991px)'),
+      `missing only query in:\n${css}`,
+    );
+    assert(
+      css.includes('@container (max-width: 991px)'),
+      `missing container max-width query in:\n${css}`,
+    );
+  });
+
+  check('the public functions and grid variables are forwarded by the entry point', () => {
+    const { css, error } = compileFixture(
+      consumerRoot,
+      `@use '@allianz/ng-aquila/styles/utils' as aquila;
+@use '@allianz/ng-aquila/styles/utils/grid' as grid;
+@use 'sass:map';
+
+.a {
+  min-width: aquila.breakpoint-min(medium);
+  max-width: aquila.breakpoint-max(medium);
+  --next: #{aquila.breakpoint-next(medium)};
+  --infix: #{aquila.breakpoint-infix(medium)};
+  --short: #{map.get(aquila.$grid-breakpoints-short, m)};
+  --columns: #{aquila.$grid-columns};
+  --gutter: #{map.get(aquila.$grid-gutter-widths, small)};
+  --gutter-large: #{grid.$grid-gutter-width-large};
+  --gutter-base: #{grid.$grid-gutter-width-base};
+  --gutter-mobile: #{grid.$grid-gutter-width-mobile};
+}
+`,
+    );
+    assert(!error, `compilation failed:\n${error}`);
+    assert(css.includes('min-width: 704px'), `missing breakpoint-min result in:\n${css}`);
+    assert(css.includes('max-width: 991px'), `missing breakpoint-max result in:\n${css}`);
+    assert(css.includes('--next: large'), `missing breakpoint-next result in:\n${css}`);
+    assert(css.includes('--infix: -medium'), `missing breakpoint-infix result in:\n${css}`);
+    assert(css.includes('--short: 704px'), `missing short breakpoint value in:\n${css}`);
+    assert(css.includes('--columns: 12'), `missing grid column count in:\n${css}`);
+    assert(
+      css.includes('--gutter: var(--grid-gutter-width-mobile, 16px)'),
+      `missing grid gutter value in:\n${css}`,
+    );
+    assert(
+      css.includes('--gutter-large: var(--grid-gutter-width-large, 32px)'),
+      `missing large grid gutter in:\n${css}`,
+    );
+    assert(
+      css.includes('--gutter-base: var(--grid-gutter-width-base, 32px)'),
+      `missing base grid gutter in:\n${css}`,
+    );
+    assert(
+      css.includes('--gutter-mobile: var(--grid-gutter-width-mobile, 16px)'),
+      `missing mobile grid gutter in:\n${css}`,
+    );
+  });
+
+  // The internal wrapper must not be published at all.
+  check('the internal breakpoint.scss wrapper is not published', () => {
+    const { error } = compileFixture(
+      consumerRoot,
+      `@use '@allianz/ng-aquila/styles/utils/breakpoint' as bp;`,
+    );
+    assert(error, 'expected the import to fail, but it compiled');
+    assert(/Can't find stylesheet/i.test(error), `expected a resolution error, got:\n${error}`);
+  });
+
+  // Defense in depth: bypass the entry point, import the real shipped dependency directly, and
+  // confirm the legacy mixin is genuinely absent. Asserting on the *specific* error keeps a typo in
+  // the fixture from passing this check.
+  check('respond-to is unreachable through the shipped breakpoints.scss', () => {
+    const { error } = compileFixture(
+      consumerRoot,
+      `@use '@allianz/ng-aquila/styles/utils/breakpoints' as bp;
+
+.a { @include bp.respond-to('medium') { color: red; } }
+`,
+    );
+    assert(error, 'expected respond-to to be undefined, but the fixture compiled');
+    assert(/Undefined mixin/i.test(error), `expected an "Undefined mixin" error, got:\n${error}`);
+    assert(
+      !/Can't find stylesheet/i.test(error),
+      `the fixture failed to resolve the stylesheet instead of proving respond-to is absent:\n${error}`,
+    );
+  });
+} finally {
+  rimrafSync(consumerRoot);
+}
+
+if (failures.length > 0) {
+  console.log('');
+  console.error(chalk.bold.red(`${failures.length} styles package check(s) failed.`));
+  process.exit(1);
+}
+
+console.log(chalk.green('  All styles package checks passed.'));


### PR DESCRIPTION
### Requirements

Please read the contribution guidelines :notebook_with_decorative_cover: beforehand and if in doubt reach out to us :pray:

#### Definition of Done

**Mandatory for all PRs**

- [x] All unit and build tests are green 🚦
- [ ] Reviewed and approved by maintainer :+1:

**Applicable to some PRs**

- [ ] W3C AA accessibility fulfilled — not applicable; this change adds Sass build-time utilities and no rendered UI.
- [x] Documentation and examples are updated.
- [ ] Tested on all supported browsers — not applicable; the API is compiled by Sass and emits standard media/container queries.
- [x] Unit tests with good coverage — consumer-level package tests cover resolution, all public helper categories, forwarded grid data, and legacy API exclusion.
- [x] No unintended visual changes.

The repository-wide Prettier check currently reports eight pre-existing TypeScript files that this PR does not modify. Every file changed by this PR passes Prettier.

### Description of the Change

Expose a curated Sass API at `@allianz/ng-aquila/styles/utils`:

- Extract the supported breakpoint and container-query functions/mixins into a clean public module.
- Preserve the existing internal breakpoint wrapper and its legacy helpers for compatibility.
- Package only the public entry point and its explicit `breakpoints.scss` and `grid.scss` dependencies.
- Add consumer-level packaging checks and run them in CI after the library build.
- Document the import path, supported helpers, breakpoint values, custom maps, and support boundary.
- Make the existing theming copy synchronous and clear the utility output before copying so package contents are deterministic.

### Why should this be in the library?

Consumers currently cannot reuse the breakpoint and media/container-query helpers that ng-aquila components use. This exposes the curated subset discussed in #61 without publishing the legacy shared-styles folder or its compatibility-only APIs.

### Verification

- `npm run build`
- `npm run test` — 54 schematics specs (6 existing pending), 16 docs UI tests, and 3,413 library tests
- `npm run lint`
- `npm run test:styles-package` — all 6 checks pass
- Prettier on every changed file

Closes #61
